### PR TITLE
Main ui change

### DIFF
--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -541,21 +541,24 @@ def updateFuelEstimate():
 
         ac.setText(tableCurrentLaps, "%.1f" % (lapsRemaining))
 
-        if currentSessionType == 2:
-            if expectedNumberOfLaps != -1:
-                currentLap = ac.getCarState(0, acsys.CS.LapCount)
-                lapPosition = ac.getCarState(0, acsys.CS.NormalizedSplinePosition)
+        if currentSessionType == 2 and expectedNumberOfLaps != -1:
+            currentLap = ac.getCarState(0, acsys.CS.LapCount)
+            lapPosition = ac.getCarState(0, acsys.CS.NormalizedSplinePosition)
 
-                lapCount = currentLap
-                if raceCrossedStartLine:
-                    lapCount = currentLap + lapPosition
+            lapCount = currentLap
+            if raceCrossedStartLine:
+                lapCount = currentLap + lapPosition
 
-                lapRemaining = expectedNumberOfLaps - lapCount
-                fuelEndOfRace = fuelRemaining - (lapRemaining * calcData.averageFuelUsed())
+            lapRemaining = expectedNumberOfLaps - lapCount
+            fuelEndOfRace = fuelRemaining - (lapRemaining * calcData.averageFuelUsed())
 
-                ac.setText(tableRaceFuel, "%d" % (fuelEndOfRace))
-                ac.setText(tableRaceTime, "%d" % ((sm.graphics.sessionTimeLeft / 1000) / 60))
-                ac.setText(tableRaceLaps, "%.1f" % (lapsRemaining))
+            ac.setText(tableRaceFuel, "%d" % (fuelEndOfRace))
+            ac.setText(tableRaceLaps, "%.1f" % (lapRemaining))
+            if sm.static.isTimedRace == 1:
+                ac.setText(tableRaceTime, "%.0f" % ((sm.graphics.sessionTimeLeft // 1000) // 60))
+            else:
+                timeRemaining = lapRemaining * calcData.averageLapTime();
+                ac.setText(tableRaceTime, "%.0f" % ((timeRemaining // 1000) // 60))
         else:
             ac.setText(tableRaceFuel, "%d" % (fuelNeeded))
             if isTimedRace:
@@ -575,20 +578,11 @@ def updateFuelEstimate():
         bestLapValueMinutes = (calcData.bestLapTime // 1000) // 60
         ac.setText(bestLapTimeValue,  "{:.0f}:{:06.3f}".format(bestLapValueMinutes, bestLapValueSeconds)[:-1])
     else:
-        timedRace = isTimedRace
-        if currentSessionType == 2:
-            timedRace = sm.static.isTimedRace == 1
-
-        if timedRace:
-            ac.setText(tableRaceLaps, "--")
-            ac.setText(tableRaceTime, "%d" % (timedRaceMinutes))
-        else:
-            ac.setText(tableRaceLaps, "%d" % (raceLaps))
-            ac.setText(tableRaceTime, "--")
-
         ac.setText(tableCurrentTime, "--")
         ac.setText(tableCurrentLaps, "--")
         ac.setText(tableRaceFuel, "--")
+        ac.setText(tableRaceTime, "--")
+        ac.setText(tableRaceLaps, "--")
         ac.setText(averageFuelPerLapValue, "--")
         ac.setText(raceTotalLapsValue, "--")
         ac.setText(averageLapTimeValue,  "--")

--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -67,6 +67,7 @@ tableCurrentLaps = None
 tableRaceFuel = None
 tableRaceTime = None
 tableRaceLaps = None
+tableRowRace = None
 
 # fuel
 
@@ -172,7 +173,7 @@ def createUI():
     global uiCreated, x_app_size, y_app_size, defaultFontSize
     global isTimedRace, timedRaceCheckbox, averageFuelPerLapValue, raceTotalLapsText, raceTotalLapsValue, bestLapTimeText, bestLapTimeValue, timedRaceMinutesSpinner, raceLapsSpinner, resetButton, timedRacePlusLapButton, timedRaceMinLapButton
     global extraLiters, extraLitersMinButton, extraLitersPlusButton, extraLitersValue, averageFuelPerLapText, extraLitersText, timedRaceText, toggleAppSizeButton, fuelLapsCountedText, fuelLapsCountedValue, calcTypeText, calcTypeCurrentButton, calcTypeMultipleButton, calcTypeStoredButton, completedLapsText, completedLapsValue, averageLapTimeText, averageLapTimeValue
-    global tableCurrentFuel, tableCurrentTime, tableCurrentLaps, tableRaceFuel, tableRaceTime, tableRaceLaps
+    global tableCurrentFuel, tableCurrentTime, tableCurrentLaps, tableRaceFuel, tableRaceTime, tableRaceLaps, tableRowRace
 
     try:
         row = 0
@@ -191,7 +192,7 @@ def createUI():
         tableCurrentLaps = createLabel("tableCurrentLaps", "--", ((x_app_size)/5) * 4, row * y_offset, defaultFontSize+2, "center")
 
         row += 1
-        createLabel("tableRowRace", "Race", x_offset, row * y_offset, defaultFontSize, "left")
+        tableRowRace = createLabel("tableRowRace", "Total Race", x_offset, row * y_offset, defaultFontSize, "left")
 
         tableRaceFuel = createLabel("tableRaceFuel", "--", ((x_app_size)/5) * 2, row * y_offset, defaultFontSize+2, "center")
         tableRaceTime = createLabel("tableRaceTime", "--", ((x_app_size)/5) * 3, row * y_offset, defaultFontSize+2, "center")
@@ -456,7 +457,7 @@ def acUpdate(deltaT):
         showMessage("Error: " + traceback.format_exc())
 
 def initNewSession(session):
-    global sessionChangedDetections, currentSessionType, sessionStartTime, completedLaps, shownCalcData, currentSessionCalcData, multipleSessionsCalcData, persistedCalcData, raceTotalSessionTime, raceCrossedStartLine
+    global sessionChangedDetections, currentSessionType, sessionStartTime, completedLaps, shownCalcData, currentSessionCalcData, multipleSessionsCalcData, persistedCalcData, raceTotalSessionTime, raceCrossedStartLine, tableRowRace
 
     currentSessionType = session
     sessionStartTime = time.time()
@@ -484,6 +485,9 @@ def initNewSession(session):
 
     if currentSessionType == 2:
         shownCalcData = currentSessionCalcData
+        ac.setText(tableRowRace, "End of Race")
+    else:
+        ac.setText(tableRowRace, "Total Race")
 
     updateUIVisibility()
     updateCalcTypeUI()
@@ -535,7 +539,7 @@ def updateFuelEstimate():
         timeRemainingSeconds = (timeRemaining / 1000) % 60
         timeRemainingMinutes = (timeRemaining // 1000) // 60
 
-        ac.setText(tableCurrentTime, "%.0f" % (timeRemainingMinutes))
+        ac.setText(tableCurrentTime, "%.0f m" % (timeRemainingMinutes))
 
         lapsRemaining = fuelRemaining / calcData.averageFuelUsed()
 
@@ -549,16 +553,16 @@ def updateFuelEstimate():
             if raceCrossedStartLine:
                 lapCount = currentLap + lapPosition
 
-            lapRemaining = expectedNumberOfLaps - lapCount
-            fuelEndOfRace = fuelRemaining - (lapRemaining * calcData.averageFuelUsed())
+            raceLapsRemaining = expectedNumberOfLaps - lapCount
+            fuelEndOfRace = fuelRemaining - (raceLapsRemaining * calcData.averageFuelUsed())
 
-            ac.setText(tableRaceFuel, "%d" % (fuelEndOfRace))
-            ac.setText(tableRaceLaps, "%.1f" % (lapRemaining))
+            ac.setText(tableRaceFuel, "%.1f" % (fuelEndOfRace))
+            ac.setText(tableRaceLaps, "%.1f" % (lapsRemaining - raceLapsRemaining))
             if sm.static.isTimedRace == 1:
-                ac.setText(tableRaceTime, "%.0f" % ((sm.graphics.sessionTimeLeft // 1000) // 60))
+                ac.setText(tableRaceTime, "%.0f m" % (((timeRemaining - sm.graphics.sessionTimeLeft) // 1000) // 60))
             else:
-                timeRemaining = lapRemaining * calcData.averageLapTime();
-                ac.setText(tableRaceTime, "%.0f" % ((timeRemaining // 1000) // 60))
+                raceTimeRemaining = raceLapsRemaining * calcData.averageLapTime();
+                ac.setText(tableRaceTime, "%.0f m" % (((timeRemaining - raceTimeRemaining) // 1000) // 60))
         else:
             ac.setText(tableRaceFuel, "%d" % (fuelNeeded))
             if isTimedRace:
@@ -566,7 +570,7 @@ def updateFuelEstimate():
             else:
                 estimatedRaceTime = raceLaps * calcData.averageLapTime()
                 estimatedRaceMinutes = (estimatedRaceTime // 1000) // 60
-                ac.setText(tableRaceTime, "%.0f" % (estimatedRaceMinutes))
+                ac.setText(tableRaceTime, "%.0f m" % (estimatedRaceMinutes))
 
             ac.setText(tableRaceLaps, "%d" % (math.ceil(laps)))
 

--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -259,7 +259,7 @@ def createUI():
 
         row = raceTypeRow
 
-        row += 2
+        row += 4
         raceLapsSpinner = ac.addSpinner(mainApp, "Race laps")
         ac.setRange(raceLapsSpinner, 0, 100)
         ac.setValue(raceLapsSpinner, raceLaps)
@@ -312,9 +312,9 @@ def updateUIVisibility():
         ac.setVisible(averageFuelPerLapText, True)
         ac.setVisible(extraLitersText, True)
         ac.setVisible(timedRaceText, True)
-        ac.setVisible(extraLitersMinButton, True)
-        ac.setVisible(extraLitersPlusButton, True)
-        ac.setVisible(resetButton, True)
+        ac.setVisible(extraLitersMinButton, currentSessionType != 2)
+        ac.setVisible(extraLitersPlusButton, currentSessionType != 2)
+        ac.setVisible(resetButton, currentSessionType != 2)
         ac.setVisible(timedRaceCheckbox, True)
         ac.setVisible(extraLitersValue, True)
         ac.setVisible(averageFuelPerLapValue, True)
@@ -324,18 +324,18 @@ def updateUIVisibility():
         ac.setVisible(fuelLapsCountedValue, True)
         ac.setVisible(calcTypeText, True)
         ac.setVisible(calcTypeCurrentButton, True)
-        ac.setVisible(calcTypeMultipleButton, True)
-        ac.setVisible(calcTypeStoredButton, True)
-        ac.setVisible(raceTotalLapsText, isTimedRace)
-        ac.setVisible(raceTotalLapsValue, isTimedRace)
-        ac.setVisible(averageLapTimeText, isTimedRace)
-        ac.setVisible(averageLapTimeValue, isTimedRace)
-        ac.setVisible(bestLapTimeText, isTimedRace)
-        ac.setVisible(bestLapTimeValue, isTimedRace)
-        ac.setVisible(timedRaceMinutesSpinner, isTimedRace)
-        ac.setVisible(timedRaceMinLapButton, isTimedRace)
-        ac.setVisible(timedRacePlusLapButton, isTimedRace)
-        ac.setVisible(raceLapsSpinner, not isTimedRace)
+        ac.setVisible(calcTypeMultipleButton, currentSessionType != 2)
+        ac.setVisible(calcTypeStoredButton, currentSessionType != 2)
+        ac.setVisible(raceTotalLapsText, True)
+        ac.setVisible(raceTotalLapsValue, True)
+        ac.setVisible(averageLapTimeText, True)
+        ac.setVisible(averageLapTimeValue, True)
+        ac.setVisible(bestLapTimeText, True)
+        ac.setVisible(bestLapTimeValue, True)
+        ac.setVisible(timedRaceMinutesSpinner, (isTimedRace and currentSessionType != 2))
+        ac.setVisible(timedRaceMinLapButton, (isTimedRace and currentSessionType != 2))
+        ac.setVisible(timedRacePlusLapButton, (isTimedRace and currentSessionType != 2))
+        ac.setVisible(raceLapsSpinner, (not isTimedRace and currentSessionType != 2))
 
     updateFuelEstimate()
 
@@ -459,12 +459,18 @@ def initNewSession(session):
         else:
             shownCalcData = multipleSessionsCalcData
 
+    if currentSessionType == 2:
+        shownCalcData = currentSessionCalcData
+
+    updateUIVisibility()
     updateCalcTypeUI()
     updateFuelEstimate()
 
 def updateFuelEstimate():
     global averageFuelPerLap, timedRaceMinutes, extraLiters, timedRaceExtraLaps, isTimedRace, raceLaps, fuelRemaining, currentSessionType, sessionStartTime, raceTotalSessionTime
     global averageFuelPerLapValue, raceFuelNeededValue, raceTotalLapsValue, extraLitersValue, raceTypeValue, fuelLapsCountedText, fuelLapsCountedValue, completedLapsValue, shownCalcData, averageLapTimeValue, raceCrossedStartLine
+
+    # TODO: Only update if we are live (AC_LIVE)
 
     calcData = shownCalcData
 

--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -469,16 +469,21 @@ def initNewSession(session):
 
     debug("Session type changed to " + str(session))
 
+    track = sm.static.track
+    trackConfiguration = ac.getTrackConfiguration(0)
+    if trackConfiguration != -1 and trackConfiguration:
+        track += "-" + trackConfiguration
+
     if currentSessionCalcData == None:
-        currentSessionCalcData = FuelCalcData(sm.static.track, sm.static.carModel, False)
+        currentSessionCalcData = FuelCalcData(track, sm.static.carModel, False)
     else:
         currentSessionCalcData.reset()
 
     if multipleSessionsCalcData == None:
-        multipleSessionsCalcData = FuelCalcData(sm.static.track, sm.static.carModel, False)
+        multipleSessionsCalcData = FuelCalcData(track, sm.static.carModel, False)
 
     if persistedCalcData == None:
-        persistedCalcData = FuelCalcData(sm.static.track, sm.static.carModel, True)
+        persistedCalcData = FuelCalcData(track, sm.static.carModel, True)
         if persistedCalcData.hasData():
             shownCalcData = persistedCalcData
         else:
@@ -558,9 +563,6 @@ def updateFuelEstimate():
             ac.setText(tableCurrentLaps, "%.1f" % (lapsRemaining))
 
             if currentSessionType == 2 and expectedNumberOfLaps != -1:
-                #currentLap = playerData.currentLap()
-                #lapPosition = playerData.lapPosition()
-
                 lapCount = currentLap
                 if raceCrossedStartLine:
                     lapCount = currentLap + lapPosition

--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -259,7 +259,7 @@ def createUI():
 
         row = raceTypeRow
 
-        row += 4
+        row += 5
         raceLapsSpinner = ac.addSpinner(mainApp, "Race laps")
         ac.setRange(raceLapsSpinner, 0, 100)
         ac.setValue(raceLapsSpinner, raceLaps)
@@ -579,7 +579,7 @@ def getExpectedRaceLaps():
                         # debug("Session time elapsed is : %d" % (sessionTimeElapsed))
                         lapCount = ac.getCarState(carId, acsys.CS.LapCount) + ac.getCarState(carId, acsys.CS.NormalizedSplinePosition)
                         # debug("Lap count is : " + str(lapCount))
-                        estimatedLaps = (raceTotalSessionTime / sessionTimeElapsed) * lapCount
+                        estimatedLaps = ((raceTotalSessionTime - 10) / sessionTimeElapsed) * lapCount # 10 seconds to account for standing start
                         # debug("Estimated number of laps : " + str(estimatedLaps))
                         return math.ceil(estimatedLaps)
                     else:

--- a/CBV_FuelCalc.py
+++ b/CBV_FuelCalc.py
@@ -3,7 +3,6 @@ version = "1.0"
 import ac, acsys, platform, os, sys, time, re, configparser, traceback, random, math
 from module.debug import debug
 from module.data import FuelCalcData
-from module.car import CarData
 
 try:
     if platform.architecture()[0] == "64bit":
@@ -437,7 +436,7 @@ def acUpdate(deltaT):
         if currentSessionType != -1:
             updateFuelEstimate()
 
-        if not lapInvalid and currentLap >=2:
+        if not lapInvalid and currentLap >= 1:
             if sm.physics.numberOfTyresOut >= 4:
                 lapInvalid = True
                 debug("Lap invalidated")
@@ -498,7 +497,7 @@ def initNewSession(session):
         shownCalcData = currentSessionCalcData
         ac.setText(tableRowRace, "End of Race")
     else:
-        ac.setText(tableRowRace, "Total Race")
+        ac.setText(tableRowRace, "Total for Race")
 
     updateUIVisibility()
     updateCalcTypeUI()

--- a/module/debug.py
+++ b/module/debug.py
@@ -5,5 +5,10 @@ appName = "CBV_FuelCalc"
 def debug(message):
     global appName
 
-    ac.log(appName + ": " + message)
-    ac.console(appName + ": " + message)
+    fileDebug = False
+    consoleDebug = False
+
+    if fileDebug:
+        ac.log(appName + ": " + message)
+    if consoleDebug:
+        ac.console(appName + ": " + message)


### PR DESCRIPTION
- Race mode added
- Displays current and estimated fuel for the race or at the end of the race
- Values displayed now in the minimized version are fuel level, time left, laps left based on fuel
- Fuel rate session setting taken into account
- Support for track layouts for persistent data
- Invalid laps (4 wheels out) are not processed
- During race mode estimated laps for a timed race is based on leader pace
- During race mode only current fuel usage is used allowing for fuel saving with visible result